### PR TITLE
Fix README path for args

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A Model Context Protocol (MCP) server for creating Google Calendar events.
      "mcpServers": {
        "google-calendar": {
          "command": "node",
-         "args": ["/Users/krilet/mcp-google-calendar-server/src/index.js"]
+         "args": ["./src/index.js"]
        }
      }
    }


### PR DESCRIPTION
## Summary
- adjust README example to use `./src/index.js` for the `args` setting

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6857054bc1f48329a6da7b19cc8a8603